### PR TITLE
Implement Htmlable to allow use of escaped Blade tags ({{ $var }})

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,13 @@ Now you can do this more convenient and easy way.
 
 ## Install
 
-Add
-
-``` JSON
-"gaaarfild/laravel-notifications": "~1.0"
-```
-
-to your `composer.json` file into `require` section.
-
-Then type in console
+To install, execute the following command in the console:
 
 ``` BASH
-$ composer update
+$ composer require "gaaarfild/laravel-notifications:~1.0"
 ```
 
-When update completed, add to your `config/app.conf` file to `providers` section
+When completed, add to your `config/app.php` file in the `providers` section
 
 ``` PHP
 'providers' => [
@@ -54,7 +46,7 @@ To change the templates, please execute the following command in the console:
 
 `php artisan vendor:publish --provider="Gaaarfild\LaravelNotifications\LaravelNotificationsServiceProvider" --tag="config"`
 
-Now you will be able to set any view file for notifications render in `/config/laravel-notifications.php`.
+Now you will be able to set any view file for notifications render in `config/laravel-notifications.php`.
 
 Optionally you can execute the following command in the console to edit the default template, instead of using your own:
 
@@ -72,7 +64,7 @@ Notifications::add('Your message text', 'type', 'group');
 
 `$type` param used especially for Twitter Bootstrap render. It displays alerts with respective class.
 
-i.e. If you set `type` to `danger`, alert with class 'alert alert-danger' will be generated on `toBootstrap()` formate method.
+i.e. If you set `type` to `danger`, alert with class 'alert alert-danger' will be generated on `toBootstrap()` format method.
 
 `$group` param groups messages to groups. :) On the next Request you can retrieve them by group.
 
@@ -133,16 +125,16 @@ Notifications::byGroup('login')->toJson();
 You can also render your notifications with custom view files
 
 ``` PHP
-Notifications::all()->toHTML();
+{{ Notifications::all() }}
 ```
 
 And you can filter them by group or type as well:
 
 
 ``` PHP
-Notifications::byType('info')->toHTML();
+{{ Notifications::byType('info') }}
 
-Notifications::byGroup('registration')->toHTML();
+{{ Notifications::byGroup('registration') }}
 ```
 
 by default method uses Twitter Bootstrap alerts format.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": ">=4.2"
+        "illuminate/support": ">=5.1.3 <5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -2,12 +2,13 @@
 
 namespace Gaaarfild\LaravelNotifications;
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\Macroable;
 
 /**
  * Class Notifications.
  */
-class Notifications
+class Notifications implements Htmlable
 {
     use Macroable;
 


### PR DESCRIPTION
Allows users to use `{{ Notification::all() }}` instead of having to manually call `toHTML()` and output using unescaped Blade tags. (`{!! Notification::all()->toHTML() !!}`)

This, unfortunately, increases the dependency of `illuminate/support` to a minimum of `5.1.3`, since that is when `Htmlable` was added. (https://github.com/laravel/framework/pull/9271)

There is also now a cap on the dependency to `<5.3` just in case they change `Htmlable` with the 5.3 release.

(P.S.: This is my last PR today, I promise! Unless there is some kind of error with this, then I'll PR a fix.)
