### PR TITLE
Fix path to where views are published.

### DIFF
--- a/src/LaravelNotificationsServiceProvider.php
+++ b/src/LaravelNotificationsServiceProvider.php
@@ -18,7 +18,7 @@ class LaravelNotificationsServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__.'/../views' => base_path('resources/views/laravel-notifications'),
+            __DIR__.'/../views' => resource_path('views/vendor/laravel-notifications'),
         ], 'views');
 
         $this->loadViewsFrom(__DIR__.'/../views', 'laravel-notifications');


### PR DESCRIPTION
Sorry, one more small (but important) fix.

Laraval will automatically pick up overwrites from `resources/views/vendor/<package-name>/` (where `<package-name>` is set as the second parameter of `$this->loadViewsFrom()`).

Anything outside of the `vendor` directory in `resources/views` is treated as a regular view, and will not overwrite a vendor-supplied view.
